### PR TITLE
Fix: Rule 'terraform_meta_arguments' no longer checks extra new line before/after when there are no other attributes.

### DIFF
--- a/docs/rules/terraform_meta_arguments.md
+++ b/docs/rules/terraform_meta_arguments.md
@@ -3,7 +3,9 @@
 Check the sequences and format of `source`, `count`, `for_each`, `providers` and
 `provider` meta-arguments in Terraform `module`, `resource` and `data source`.
 Any comment lines before the meta-arguments are allowed, but an extra newline must
-be placed under each meta-arguments except meta-argument `lifecycle`.
+be placed under each meta-arguments except meta-argument `lifecycle`. If there are
+no other attributes before/after the meta-arguments, then new line condition is
+not checked.
 
 ## Terraform `module`
 

--- a/project/main.go
+++ b/project/main.go
@@ -1,0 +1,7 @@
+package project
+
+import "fmt"
+
+func ReferenceLink(name string) string {
+	return fmt.Sprintf("https://github.com/myklst/tflint-ruleset-myklst/blob/main/docs/rules/%s.md", name)
+}

--- a/rules/terraform_any_type_variables.go
+++ b/rules/terraform_any_type_variables.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/myklst/tflint-ruleset-myklst/project"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
@@ -39,7 +40,7 @@ func (r *TerraformAnyTypeVariables) Severity() tflint.Severity {
 
 // Link returns the rule reference link
 func (r *TerraformAnyTypeVariables) Link() string {
-	return "https://github.com/myklst/tflint-ruleset-myklst/docs/rules/terraform_any_type_variables.md"
+	return project.ReferenceLink(r.Name())
 }
 
 // Check checks whether variables have type

--- a/rules/terraform_meta_arguments.go
+++ b/rules/terraform_meta_arguments.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/myklst/tflint-ruleset-myklst/project"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
 
@@ -36,7 +37,7 @@ func (r *TerraformMetaArguments) Severity() tflint.Severity {
 
 // Link returns the rule reference link
 func (r *TerraformMetaArguments) Link() string {
-	return "https://github.com/myklst/tflint-ruleset-myklst/docs/rules/terraform_meta_arguments.md"
+	return project.ReferenceLink(r.Name())
 }
 
 // Check checks whether variables have type

--- a/rules/terraform_meta_arguments_test.go
+++ b/rules/terraform_meta_arguments_test.go
@@ -18,13 +18,21 @@ func Test_TerraformMetaArguments(t *testing.T) {
 			Content: `
 module "my_module" {
   source = "./my-module/"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "source and attributes in module",
+			Content: `
+module "my_module" {
+  source = "./my-module/"
 
   name = "my name"
 }`,
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "source only in module with comment",
+			Name: "source and attributes in module with comment",
 			Content: `
 module "my_module" {
   # I'm a comment.
@@ -35,7 +43,7 @@ module "my_module" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "source and count only in module",
+			Name: "source, count and attributes in module",
 			Content: `
 module "my_module" {
   source = "./my-module/"
@@ -47,7 +55,7 @@ module "my_module" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "source and count only in module with comments",
+			Name: "source, count and attributes in module with comments",
 			Content: `
 module "my_module" {
   # I'm first comment.
@@ -61,7 +69,7 @@ module "my_module" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "source and for_each only in module",
+			Name: "source, for_each and attributes in module",
 			Content: `
 module "my_module" {
   source = "./my-module/"
@@ -73,7 +81,7 @@ module "my_module" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "source and for_each only in module with comments",
+			Name: "source, for_each and attributes in module with comments",
 			Content: `
 module "my_module" {
   # I'm first comment.
@@ -87,7 +95,7 @@ module "my_module" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "source, count and providers in module",
+			Name: "source, count, providers and attributes in module",
 			Content: `
 module "my_module" {
   source = "./my-module/"
@@ -101,7 +109,7 @@ module "my_module" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "source, count and providers in module with comments",
+			Name: "source, count, providers and attributes in module with comments",
 			Content: `
 module "my_module" {
   # I'm first comment.
@@ -118,7 +126,7 @@ module "my_module" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "source, for_each and providers in module",
+			Name: "source, for_each, providers and attributes in module",
 			Content: `
 module "my_module" {
   source = "./my-module/"
@@ -132,7 +140,7 @@ module "my_module" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "source, for_each and providers in module with comments",
+			Name: "source, for_each, providers and attributes in module with comments",
 			Content: `
 module "my_module" {
   # I'm first comment.
@@ -153,19 +161,6 @@ module "my_module" {
 			Content: `
 resource "foo" "my_resource" {
   count = 3
-
-  name = "my name"
-}`,
-			Expected: helper.Issues{},
-		},
-		{
-			Name: "count only in resource with comment",
-			Content: `
-resource "foo" "my_resource" {
-  # I'm a comment.
-  count = 3
-
-  name = "my name"
 }`,
 			Expected: helper.Issues{},
 		},
@@ -174,13 +169,40 @@ resource "foo" "my_resource" {
 			Content: `
 resource "foo" "my_resource" {
   for_each = {}
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "provider only in resource",
+			Content: `
+resource "foo" "my_resource" {
+  provider = foo.default
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "count and attributes in resource with comment",
+			Content: `
+resource "foo" "my_resource" {
+  # I'm a comment.
+  count = 3
 
   name = "my name"
 }`,
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "for_each only in resource with comment",
+			Name: "for_each and attributes in resource",
+			Content: `
+resource "foo" "my_resource" {
+  for_each = {}
+
+  name = "my name"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "for_each and attributes in resource with comment",
 			Content: `
 resource "foo" "my_resource" {
   # I'm a comment.
@@ -191,7 +213,7 @@ resource "foo" "my_resource" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "provider only in resource",
+			Name: "provider and attributes in resource",
 			Content: `
 resource "foo" "my_resource" {
   provider = foo.default
@@ -201,7 +223,7 @@ resource "foo" "my_resource" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "provider only in resource with comment",
+			Name: "provider and attributes in resource with comment",
 			Content: `
 resource "foo" "my_resource" {
   # I'm a comment.
@@ -212,7 +234,7 @@ resource "foo" "my_resource" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "count and provider in resource",
+			Name: "count, provider and attributes in resource",
 			Content: `
 resource "foo" "my_resource" {
   count = 3
@@ -224,7 +246,7 @@ resource "foo" "my_resource" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "count and provider in resource with comments",
+			Name: "count, provider and attributes in resource with comments",
 			Content: `
 resource "foo" "my_resource" {
   # I'm a comment.
@@ -237,7 +259,7 @@ resource "foo" "my_resource" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "count and provider in data source",
+			Name: "count, provider and attributes in data source",
 			Content: `
 data "foo" "my_resource" {
   count = 3
@@ -249,7 +271,7 @@ data "foo" "my_resource" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "count and provider in data source with comments",
+			Name: "count, provider and attributes in data source with comments",
 			Content: `
 data "foo" "my_resource" {
   # I'm first comment.
@@ -263,7 +285,15 @@ data "foo" "my_resource" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "lifecycle in resource",
+			Name: "lifecycle only in resource",
+			Content: `
+resource "foo" "my_resource" {
+  lifecycle {}
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "lifecycle and attributes in resource",
 			Content: `
 resource "foo" "my_resource" {
   name = "my name"
@@ -273,7 +303,7 @@ resource "foo" "my_resource" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "lifecycle in resource with comment",
+			Name: "lifecycle and attributes in resource with comment",
 			Content: `
 resource "foo" "my_resource" {
   name = "my name"
@@ -284,7 +314,7 @@ resource "foo" "my_resource" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "count, provider and lifecycle in resource",
+			Name: "count, provider, lifecycle and attributes in resource",
 			Content: `
 resource "foo" "my_resource" {
   count = 3
@@ -298,7 +328,7 @@ resource "foo" "my_resource" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "count, provider and lifecycle in resource with comments",
+			Name: "count, provider, lifecycle and attributes in resource with comments",
 			Content: `
 resource "foo" "my_resource" {
   # I'm first comment.
@@ -315,7 +345,7 @@ resource "foo" "my_resource" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "source only in module, invalid arrangement",
+			Name: "source and attributes in module, invalid arrangement",
 			Content: `
 module "my_module" {
 
@@ -336,7 +366,7 @@ module "my_module" {
 			},
 		},
 		{
-			Name: "source and count in module, invalid arrangement",
+			Name: "source, count and attributes in module, invalid arrangement",
 			Content: `
 module "my_module" {
   count = 3
@@ -358,7 +388,7 @@ module "my_module" {
 			},
 		},
 		{
-			Name: "count, provider in resource, invalid arrangement",
+			Name: "count, provider and attributes in resource, invalid arrangement",
 			Content: `
 resource "foo" "my_resource" {
   provider = foo.default
@@ -380,7 +410,7 @@ resource "foo" "my_resource" {
 			},
 		},
 		{
-			Name: "count, provider and lifecycle in resource, invalid arrangement",
+			Name: "count, provider, lifecycle and attributes in resource, invalid arrangement",
 			Content: `
 resource "foo" "my_resource" {
   count = 3
@@ -398,13 +428,13 @@ resource "foo" "my_resource" {
 					Range: hcl.Range{
 						Filename: "main.tf",
 						Start:    hcl.Pos{Line: 7, Column: 3},
-						End:      hcl.Pos{Line: 7, Column: 15},
+						End:      hcl.Pos{Line: 7, Column: 12},
 					},
 				},
 			},
 		},
 		{
-			Name: "source, count and providers in module, invalid arrangement",
+			Name: "source, count, providers and attributes in module, invalid arrangement",
 			Content: `
 module "my_module" {
   source = "./my-module/"
@@ -428,7 +458,7 @@ module "my_module" {
 			},
 		},
 		{
-			Name: "source only in module, missing new line",
+			Name: "source and attributes in module, missing new line",
 			Content: `
 module "my_module" {
   source = "./my-module/"
@@ -447,7 +477,7 @@ module "my_module" {
 			},
 		},
 		{
-			Name: "source and count only in module, missing new line",
+			Name: "source, count and attributes in module, missing new line",
 			Content: `
 module "my_module" {
   source = "./my-module/"
@@ -468,7 +498,7 @@ module "my_module" {
 			},
 		},
 		{
-			Name: "source, count and providers in module, missing new line",
+			Name: "source, count, providers and attributes in module, missing new line",
 			Content: `
 module "my_module" {
   source = "./my-module/"
@@ -491,7 +521,7 @@ module "my_module" {
 			},
 		},
 		{
-			Name: "lifecycle in resource, missing new line",
+			Name: "lifecycle and attributes in resource, missing new line",
 			Content: `
 resource "foo" "my_resource" {
   name = "my name"
@@ -504,13 +534,13 @@ resource "foo" "my_resource" {
 					Range: hcl.Range{
 						Filename: "main.tf",
 						Start:    hcl.Pos{Line: 4, Column: 3},
-						End:      hcl.Pos{Line: 4, Column: 15},
+						End:      hcl.Pos{Line: 4, Column: 12},
 					},
 				},
 			},
 		},
 		{
-			Name: "lifecycle in resource with comment, missing new line",
+			Name: "lifecycle and attributes in resource with comment, missing new line",
 			Content: `
 resource "foo" "my_resource" {
   name = "my name"
@@ -524,7 +554,7 @@ resource "foo" "my_resource" {
 					Range: hcl.Range{
 						Filename: "main.tf",
 						Start:    hcl.Pos{Line: 5, Column: 3},
-						End:      hcl.Pos{Line: 5, Column: 15},
+						End:      hcl.Pos{Line: 5, Column: 12},
 					},
 				},
 			},

--- a/rules/terraform_module_source_version.go
+++ b/rules/terraform_module_source_version.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/hashicorp/go-getter"
+	"github.com/myklst/tflint-ruleset-myklst/project"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
@@ -43,10 +44,10 @@ func (r *TerraformModuleSourceVersion) Severity() tflint.Severity {
 
 // Link returns the rule reference link
 func (r *TerraformModuleSourceVersion) Link() string {
-	return "https://github.com/myklst/tflint-ruleset-myklst/docs/rules/terraform_module_source_version.md"
+	return project.ReferenceLink(r.Name())
 }
 
-// Link returns the rule reference link
+// Check checks whether module source have version
 func (r *TerraformModuleSourceVersion) Check(runner tflint.Runner) error {
 	config := &TerraformModuleSourceVersionConfig{}
 

--- a/rules/terraform_required_tags.go
+++ b/rules/terraform_required_tags.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/myklst/tflint-ruleset-myklst/project"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/zclconf/go-cty/cty"
@@ -43,7 +44,7 @@ func (r *TerraformRequiredTags) Severity() tflint.Severity {
 
 // Link returns the rule reference link
 func (r *TerraformRequiredTags) Link() string {
-	return "https://github.com/myklst/tflint-ruleset-myklst/docs/rules/terraform_required_tags.md"
+	return project.ReferenceLink(r.Name())
 }
 
 // Check checks whether resources have the required tags if applicable

--- a/rules/terraform_required_variables.go
+++ b/rules/terraform_required_variables.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/myklst/tflint-ruleset-myklst/project"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
@@ -41,7 +42,7 @@ func (r *TerraformRequiredVariables) Severity() tflint.Severity {
 
 // Link returns the rule reference link
 func (r *TerraformRequiredVariables) Link() string {
-	return "https://github.com/myklst/tflint-ruleset-myklst/docs/rules/terraform_required_variables.md"
+	return project.ReferenceLink(r.Name())
 }
 
 // Check checks whether required_vars have been declared as variables within the module

--- a/rules/terraform_vars_object_keys_naming_conventions.go
+++ b/rules/terraform_vars_object_keys_naming_conventions.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/myklst/tflint-ruleset-myklst/project"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/zclconf/go-cty/cty"
@@ -68,7 +69,7 @@ func (r *TerraformVarsObjectKeysNamingConventions) Severity() tflint.Severity {
 
 // Link returns the rule reference link
 func (r *TerraformVarsObjectKeysNamingConventions) Link() string {
-	return "https://github.com/myklst/tflint-ruleset-myklst/docs/rules/teraform_vars_object_keys_naming_conventions.md"
+	return project.ReferenceLink(r.Name())
 }
 
 // Check verifies that top-level attributes in object-type variables follow naming standards.


### PR DESCRIPTION
**🔧 Fixes in rule 'terraform_meta_arguments'**
- This rule no longer checks extra new line before/after when there are no other attributes around.

**🎓 Why is this fix required?**
- Some modules/resources/data sources might not have any required attributes, in this case have extra new line before/after the meta-arguments is not appropriate.

**📌 For example**
- no required input variables in the module: 
  ```
  module "my_module" {
    source = "./my-module/"
  }
  ```
- no required attributes in the resources:
  ```
  resource "foo" "my_resource" {
    count = 3
  }
  ```
- no required attributes in data sources:
  ```
  data "foo" "my_resource" {
    provider = foo.default
  }
  ```
  
---
**🔧 General fixes**
- Fixes invalid document link in all rules.